### PR TITLE
Add reserved key checks for custom bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed trailing newline in lint configuration
 - Restored additional linters in `.golangci.yml` while keeping `make lint` passing
 - Fixed lint configuration error by specifying `colored-line-number` output format
+- Added support for customizing key bindings via `key_bindings` config section
+- Key bindings now support modifiers (e.g. `Ctrl+A`) and are validated on load
+- Validation now prevents duplicate or reserved key bindings
+- Validation also blocks system reserved combinations such as `Ctrl+C`
 
 ## [0.7.1] - 2025-07-01
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,29 @@ debug: false
 # cache_dir: "/custom/cache/path"  # Optional: defaults to ~/.cache/proxmox-tui
 ```
 
+#### Custom Key Bindings
+
+Add a `key_bindings` section to redefine most shortcuts. Keys may include
+modifiers like `Ctrl`, `Alt`, `Shift`, or `Win` (e.g. `Ctrl+S`):
+
+```yaml
+key_bindings:
+  switch_view: Ctrl+Tab
+  nodes_page: F1
+  guests_page: F2
+  tasks_page: F3
+  menu: M
+  shell: S
+  vnc: V
+  scripts: C
+  refresh: F5
+  auto_refresh: A
+  search: "/"
+  help: "?"
+  quit: Q
+```
+If a binding is omitted, the default for that action is used. Each shortcut must be unique, and the following keys are reserved for navigation and cannot be reassigned: `h`, `j`, `k`, `l`, arrow keys, `Tab`, `Enter`, `Esc`, `Backspace`, and `q`.  Additionally, system shortcuts such as `Ctrl+C` (interrupt), `Ctrl+D` (EOF), and `Ctrl+Z` (suspend) are not allowed.
+
 ## 🔐 Authentication
 
 Proxmox TUI supports two authentication methods:

--- a/configs/config.tpl.yml
+++ b/configs/config.tpl.yml
@@ -4,8 +4,25 @@ user: root
 # password: "1234567890"
 token_id: "tui"
 token_secret: "1234567890"
-realm: "pam"
+realm: pam
 insecure: true
 ssh_user: root
 debug: false
 # cache_dir: "/custom/cache/path"  # Optional: defaults to $XDG_CACHE_HOME/proxmox-tui or ~/.cache/proxmox-tui
+
+key_bindings:
+  switch_view: Ctrl+Tab
+  nodes_page: F1
+  guests_page: F2
+  tasks_page: F3
+  menu: M
+  shell: S
+  vnc: V
+  scripts: C
+  refresh: F5
+  auto_refresh: A
+  search: "/"
+  help: "?"
+  quit: Q
+# Reserved keys (h, j, k, l, arrows, Tab, Enter, Esc, Backspace, q) cannot be reassigned.
+# System combos like Ctrl+C, Ctrl+D and Ctrl+Z are also blocked.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/devnullvoid/proxmox-tui/internal/keys"
 	"gopkg.in/yaml.v3"
 )
 
@@ -83,6 +84,25 @@ import (
 // This variable is set during configuration parsing and used by various
 // components to determine whether to emit debug-level log messages.
 var DebugEnabled bool
+
+// KeyBindings defines customizable key mappings for common actions.
+// Each field represents a single keyboard key that triggers the action.
+// Only single characters and function keys (e.g. "F1") are supported.
+type KeyBindings struct {
+	SwitchView  string `yaml:"switch_view"`  // Switch between pages
+	NodesPage   string `yaml:"nodes_page"`   // Jump to Nodes page
+	GuestsPage  string `yaml:"guests_page"`  // Jump to Guests page
+	TasksPage   string `yaml:"tasks_page"`   // Jump to Tasks page
+	Menu        string `yaml:"menu"`         // Open context menu
+	Shell       string `yaml:"shell"`        // Open shell session
+	VNC         string `yaml:"vnc"`          // Open VNC console
+	Scripts     string `yaml:"scripts"`      // Install community scripts
+	Refresh     string `yaml:"refresh"`      // Manual refresh
+	AutoRefresh string `yaml:"auto_refresh"` // Toggle auto-refresh
+	Search      string `yaml:"search"`       // Activate search
+	Help        string `yaml:"help"`         // Toggle help modal
+	Quit        string `yaml:"quit"`         // Quit application
+}
 
 // Config represents the complete application configuration with support for
 // multiple authentication methods and XDG-compliant directory handling.
@@ -106,17 +126,77 @@ var DebugEnabled bool
 //		Debug:    true,
 //	}
 type Config struct {
-	Addr        string `yaml:"addr"`         // Proxmox server URL (e.g., "https://pve.example.com:8006")
-	User        string `yaml:"user"`         // Username for authentication (without realm)
-	Password    string `yaml:"password"`     // Password for password-based authentication
-	TokenID     string `yaml:"token_id"`     // API token ID for token-based authentication
-	TokenSecret string `yaml:"token_secret"` // API token secret for token-based authentication
-	Realm       string `yaml:"realm"`        // Authentication realm (e.g., "pam", "pve")
-	ApiPath     string `yaml:"api_path"`     // API base path (default: "/api2/json")
-	Insecure    bool   `yaml:"insecure"`     // Skip TLS certificate verification
-	SSHUser     string `yaml:"ssh_user"`     // SSH username for shell connections
-	Debug       bool   `yaml:"debug"`        // Enable debug logging
-	CacheDir    string `yaml:"cache_dir"`    // Custom cache directory path
+	Addr        string      `yaml:"addr"`         // Proxmox server URL (e.g., "https://pve.example.com:8006")
+	User        string      `yaml:"user"`         // Username for authentication (without realm)
+	Password    string      `yaml:"password"`     // Password for password-based authentication
+	TokenID     string      `yaml:"token_id"`     // API token ID for token-based authentication
+	TokenSecret string      `yaml:"token_secret"` // API token secret for token-based authentication
+	Realm       string      `yaml:"realm"`        // Authentication realm (e.g., "pam", "pve")
+	ApiPath     string      `yaml:"api_path"`     // API base path (default: "/api2/json")
+	Insecure    bool        `yaml:"insecure"`     // Skip TLS certificate verification
+	SSHUser     string      `yaml:"ssh_user"`     // SSH username for shell connections
+	Debug       bool        `yaml:"debug"`        // Enable debug logging
+	CacheDir    string      `yaml:"cache_dir"`    // Custom cache directory path
+	KeyBindings KeyBindings `yaml:"key_bindings"` // Customizable key bindings
+}
+
+// ValidateKeyBindings checks if all key specifications are valid.
+func ValidateKeyBindings(kb KeyBindings) error {
+	bindings := map[string]string{
+		"switch_view":  kb.SwitchView,
+		"nodes_page":   kb.NodesPage,
+		"guests_page":  kb.GuestsPage,
+		"tasks_page":   kb.TasksPage,
+		"menu":         kb.Menu,
+		"shell":        kb.Shell,
+		"vnc":          kb.VNC,
+		"scripts":      kb.Scripts,
+		"refresh":      kb.Refresh,
+		"auto_refresh": kb.AutoRefresh,
+		"search":       kb.Search,
+		"help":         kb.Help,
+		"quit":         kb.Quit,
+	}
+
+	defaults := map[string]string{
+		"switch_view":  "Tab",
+		"nodes_page":   "F1",
+		"guests_page":  "F2",
+		"tasks_page":   "F3",
+		"menu":         "M",
+		"shell":        "S",
+		"vnc":          "V",
+		"scripts":      "C",
+		"refresh":      "F5",
+		"auto_refresh": "A",
+		"search":       "/",
+		"help":         "?",
+		"quit":         "Q",
+	}
+
+	seen := make(map[string]string)
+
+	for name, spec := range bindings {
+		if spec == "" {
+			continue
+		}
+		key, r, mod, err := keys.Parse(spec)
+		if err != nil {
+			return fmt.Errorf("invalid key binding %s: %w", name, err)
+		}
+
+		if keys.IsReserved(key, r, mod) && spec != defaults[name] {
+			return fmt.Errorf("key binding %s uses reserved key %s", name, spec)
+		}
+
+		id := keys.CanonicalID(key, r, mod)
+		if other, ok := seen[id]; ok {
+			return fmt.Errorf("key binding %s duplicates %s", name, other)
+		}
+		seen[id] = name
+	}
+
+	return nil
 }
 
 // getXDGCacheDir returns the XDG-compliant cache directory for the application.
@@ -238,6 +318,21 @@ func NewConfig() *Config {
 		SSHUser:     os.Getenv("PROXMOX_SSH_USER"),
 		Debug:       strings.ToLower(os.Getenv("PROXMOX_DEBUG")) == "true",
 		CacheDir:    os.Getenv("PROXMOX_CACHE_DIR"),
+		KeyBindings: KeyBindings{
+			SwitchView:  "Tab",
+			NodesPage:   "F1",
+			GuestsPage:  "F2",
+			TasksPage:   "F3",
+			Menu:        "M",
+			Shell:       "S",
+			VNC:         "V",
+			Scripts:     "C",
+			Refresh:     "F5",
+			AutoRefresh: "A",
+			Search:      "/",
+			Help:        "?",
+			Quit:        "Q",
+		},
 	}
 }
 
@@ -299,6 +394,21 @@ func (c *Config) MergeWithFile(path string) error {
 		SSHUser     string `yaml:"ssh_user"`
 		Debug       *bool  `yaml:"debug"`
 		CacheDir    string `yaml:"cache_dir"`
+		KeyBindings struct {
+			SwitchView  string `yaml:"switch_view"`
+			NodesPage   string `yaml:"nodes_page"`
+			GuestsPage  string `yaml:"guests_page"`
+			TasksPage   string `yaml:"tasks_page"`
+			Menu        string `yaml:"menu"`
+			Shell       string `yaml:"shell"`
+			VNC         string `yaml:"vnc"`
+			Scripts     string `yaml:"scripts"`
+			Refresh     string `yaml:"refresh"`
+			AutoRefresh string `yaml:"auto_refresh"`
+			Search      string `yaml:"search"`
+			Help        string `yaml:"help"`
+			Quit        string `yaml:"quit"`
+		} `yaml:"key_bindings"`
 	}
 
 	if err := yaml.Unmarshal(data, &fileConfig); err != nil {
@@ -339,6 +449,62 @@ func (c *Config) MergeWithFile(path string) error {
 	if fileConfig.CacheDir != "" {
 		c.CacheDir = fileConfig.CacheDir
 	}
+	// Merge key bindings if provided
+	if kb := fileConfig.KeyBindings; kb != struct {
+		SwitchView  string `yaml:"switch_view"`
+		NodesPage   string `yaml:"nodes_page"`
+		GuestsPage  string `yaml:"guests_page"`
+		TasksPage   string `yaml:"tasks_page"`
+		Menu        string `yaml:"menu"`
+		Shell       string `yaml:"shell"`
+		VNC         string `yaml:"vnc"`
+		Scripts     string `yaml:"scripts"`
+		Refresh     string `yaml:"refresh"`
+		AutoRefresh string `yaml:"auto_refresh"`
+		Search      string `yaml:"search"`
+		Help        string `yaml:"help"`
+		Quit        string `yaml:"quit"`
+	}{} {
+		if kb.SwitchView != "" {
+			c.KeyBindings.SwitchView = kb.SwitchView
+		}
+		if kb.NodesPage != "" {
+			c.KeyBindings.NodesPage = kb.NodesPage
+		}
+		if kb.GuestsPage != "" {
+			c.KeyBindings.GuestsPage = kb.GuestsPage
+		}
+		if kb.TasksPage != "" {
+			c.KeyBindings.TasksPage = kb.TasksPage
+		}
+		if kb.Menu != "" {
+			c.KeyBindings.Menu = kb.Menu
+		}
+		if kb.Shell != "" {
+			c.KeyBindings.Shell = kb.Shell
+		}
+		if kb.VNC != "" {
+			c.KeyBindings.VNC = kb.VNC
+		}
+		if kb.Scripts != "" {
+			c.KeyBindings.Scripts = kb.Scripts
+		}
+		if kb.Refresh != "" {
+			c.KeyBindings.Refresh = kb.Refresh
+		}
+		if kb.AutoRefresh != "" {
+			c.KeyBindings.AutoRefresh = kb.AutoRefresh
+		}
+		if kb.Search != "" {
+			c.KeyBindings.Search = kb.Search
+		}
+		if kb.Help != "" {
+			c.KeyBindings.Help = kb.Help
+		}
+		if kb.Quit != "" {
+			c.KeyBindings.Quit = kb.Quit
+		}
+	}
 
 	return nil
 }
@@ -361,6 +527,10 @@ func (c *Config) Validate() error {
 
 	if hasPassword && hasToken {
 		return errors.New("conflicting authentication methods: provide either password or API token, not both")
+	}
+
+	if err := ValidateKeyBindings(c.KeyBindings); err != nil {
+		return err
 	}
 
 	return nil
@@ -400,5 +570,46 @@ func (c *Config) SetDefaults() {
 	if c.CacheDir == "" {
 		// Use XDG_CACHE_HOME for cache directory
 		c.CacheDir = getXDGCacheDir()
+	}
+
+	// Apply default key bindings if not set
+	if c.KeyBindings.SwitchView == "" {
+		c.KeyBindings.SwitchView = "Tab"
+	}
+	if c.KeyBindings.NodesPage == "" {
+		c.KeyBindings.NodesPage = "F1"
+	}
+	if c.KeyBindings.GuestsPage == "" {
+		c.KeyBindings.GuestsPage = "F2"
+	}
+	if c.KeyBindings.TasksPage == "" {
+		c.KeyBindings.TasksPage = "F3"
+	}
+	if c.KeyBindings.Menu == "" {
+		c.KeyBindings.Menu = "M"
+	}
+	if c.KeyBindings.Shell == "" {
+		c.KeyBindings.Shell = "S"
+	}
+	if c.KeyBindings.VNC == "" {
+		c.KeyBindings.VNC = "V"
+	}
+	if c.KeyBindings.Scripts == "" {
+		c.KeyBindings.Scripts = "C"
+	}
+	if c.KeyBindings.Refresh == "" {
+		c.KeyBindings.Refresh = "F5"
+	}
+	if c.KeyBindings.AutoRefresh == "" {
+		c.KeyBindings.AutoRefresh = "A"
+	}
+	if c.KeyBindings.Search == "" {
+		c.KeyBindings.Search = "/"
+	}
+	if c.KeyBindings.Help == "" {
+		c.KeyBindings.Help = "?"
+	}
+	if c.KeyBindings.Quit == "" {
+		c.KeyBindings.Quit = "Q"
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -452,6 +452,32 @@ func TestGetDefaultConfigPath(t *testing.T) {
 	assert.True(t, filepath.IsAbs(result))
 }
 
+func TestValidateKeyBindings(t *testing.T) {
+	t.Run("duplicate", func(t *testing.T) {
+		kb := KeyBindings{SwitchView: "F1", NodesPage: "F1"}
+		err := ValidateKeyBindings(kb)
+		assert.Error(t, err)
+	})
+
+	t.Run("reserved", func(t *testing.T) {
+		kb := KeyBindings{Menu: "h"}
+		err := ValidateKeyBindings(kb)
+		assert.Error(t, err)
+	})
+
+	t.Run("system reserved", func(t *testing.T) {
+		kb := KeyBindings{Quit: "Ctrl+C"}
+		err := ValidateKeyBindings(kb)
+		assert.Error(t, err)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		kb := KeyBindings{SwitchView: "Ctrl+A", NodesPage: "F1"}
+		err := ValidateKeyBindings(kb)
+		assert.NoError(t, err)
+	})
+}
+
 // Helper function to clear all Proxmox environment variables
 func clearProxmoxEnvVars() {
 	envVars := []string{

--- a/internal/keys/parse.go
+++ b/internal/keys/parse.go
@@ -1,0 +1,133 @@
+package keys
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// Parse converts a key specification like "Ctrl+A" or "F5" to tcell values.
+// It returns the key, optional rune, and modifier mask.
+func Parse(spec string) (tcell.Key, rune, tcell.ModMask, error) {
+	if spec == "" {
+		return 0, 0, 0, fmt.Errorf("empty key specification")
+	}
+
+	parts := strings.Split(spec, "+")
+	base := strings.TrimSpace(parts[len(parts)-1])
+	var mods tcell.ModMask
+	for _, p := range parts[:len(parts)-1] {
+		switch strings.ToLower(strings.TrimSpace(p)) {
+		case "ctrl", "control":
+			mods |= tcell.ModCtrl
+		case "alt":
+			mods |= tcell.ModAlt
+		case "shift":
+			mods |= tcell.ModShift
+		case "meta", "win", "windows":
+			mods |= tcell.ModMeta
+		case "":
+			// ignore empty segment like "Ctrl+"
+		default:
+			return 0, 0, 0, fmt.Errorf("unknown modifier %q", p)
+		}
+	}
+
+	b := strings.ToUpper(base)
+	switch b {
+	case "TAB":
+		return tcell.KeyTab, 0, mods, nil
+	case "ENTER", "RETURN":
+		return tcell.KeyEnter, 0, mods, nil
+	case "ESC", "ESCAPE":
+		return tcell.KeyEsc, 0, mods, nil
+	case "UP":
+		return tcell.KeyUp, 0, mods, nil
+	case "DOWN":
+		return tcell.KeyDown, 0, mods, nil
+	case "LEFT":
+		return tcell.KeyLeft, 0, mods, nil
+	case "RIGHT":
+		return tcell.KeyRight, 0, mods, nil
+	}
+
+	if strings.HasPrefix(b, "F") {
+		if n, err := strconv.Atoi(strings.TrimPrefix(b, "F")); err == nil {
+			switch n {
+			case 1:
+				return tcell.KeyF1, 0, mods, nil
+			case 2:
+				return tcell.KeyF2, 0, mods, nil
+			case 3:
+				return tcell.KeyF3, 0, mods, nil
+			case 4:
+				return tcell.KeyF4, 0, mods, nil
+			case 5:
+				return tcell.KeyF5, 0, mods, nil
+			case 6:
+				return tcell.KeyF6, 0, mods, nil
+			case 7:
+				return tcell.KeyF7, 0, mods, nil
+			case 8:
+				return tcell.KeyF8, 0, mods, nil
+			case 9:
+				return tcell.KeyF9, 0, mods, nil
+			case 10:
+				return tcell.KeyF10, 0, mods, nil
+			case 11:
+				return tcell.KeyF11, 0, mods, nil
+			case 12:
+				return tcell.KeyF12, 0, mods, nil
+			}
+		}
+	}
+
+	if len([]rune(base)) == 1 {
+		r := []rune(strings.ToLower(base))[0]
+		return tcell.KeyRune, r, mods, nil
+	}
+
+	return 0, 0, 0, fmt.Errorf("unknown key %q", base)
+}
+
+// Validate returns an error if the key specification is not recognized.
+func Validate(spec string) error {
+	_, _, _, err := Parse(spec)
+	return err
+}
+
+// CanonicalID returns a unique identifier for a parsed key combination.
+func CanonicalID(key tcell.Key, r rune, mod tcell.ModMask) string {
+	return fmt.Sprintf("%d:%d:%d", key, r, mod)
+}
+
+// IsReserved reports whether the given key combination is reserved for
+// navigation and should not be reassigned. Only unmodified keys are checked.
+func IsReserved(key tcell.Key, r rune, mod tcell.ModMask) bool {
+	// Unmodified navigation keys cannot be remapped.
+	if mod == 0 {
+		switch key {
+		case tcell.KeyUp, tcell.KeyDown, tcell.KeyLeft, tcell.KeyRight,
+			tcell.KeyEsc, tcell.KeyEnter, tcell.KeyBackspace, tcell.KeyBackspace2,
+			tcell.KeyTab:
+			return true
+		case tcell.KeyRune:
+			switch unicode.ToLower(r) {
+			case 'h', 'j', 'k', 'l', 'q':
+				return true
+			}
+		}
+	}
+
+	// System-reserved combinations like Ctrl+C should not be reused.
+	if mod == tcell.ModCtrl && key == tcell.KeyRune {
+		switch unicode.ToLower(r) {
+		case 'c', 'd', 'z':
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ui/components/app.go
+++ b/internal/ui/components/app.go
@@ -78,13 +78,14 @@ func NewApp(ctx context.Context, client *api.Client, cfg *config.Config) *App {
 	// Initialize components
 	app.header = NewHeader()
 	app.footer = NewFooter()
+	app.footer.UpdateKeybindings(FormatFooterText(cfg.KeyBindings))
 	app.nodeList = NewNodeList()
 	app.vmList = NewVMList()
 	app.nodeDetails = NewNodeDetails()
 	app.vmDetails = NewVMDetails()
 	app.tasksList = NewTasksList()
 	app.clusterStatus = NewClusterStatus()
-	app.helpModal = NewHelpModal()
+	app.helpModal = NewHelpModal(cfg.KeyBindings)
 
 	// Set app reference for components that need it
 	app.header.SetApp(app.Application)

--- a/internal/ui/components/footer.go
+++ b/internal/ui/components/footer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/devnullvoid/proxmox-tui/internal/config"
 	"github.com/rivo/tview"
 )
 
@@ -38,6 +39,22 @@ func NewFooter() *Footer {
 	f.updateDisplay()
 
 	return f
+}
+
+// FormatFooterText builds the footer key binding text from config.
+func FormatFooterText(keys config.KeyBindings) string {
+	return fmt.Sprintf(
+		"[yellow]%s:[white]Switch  [yellow]%s:[white]Nodes  [yellow]%s:[white]Guests  [yellow]%s:[white]Tasks  [yellow]%s:[white]Search  [yellow]%s:[white]Menu  [yellow]%s:[white]Auto-Refresh  [yellow]%s:[white]Help  [yellow]%s:[white]Quit",
+		keys.SwitchView,
+		keys.NodesPage,
+		keys.GuestsPage,
+		keys.TasksPage,
+		keys.Search,
+		keys.Menu,
+		keys.AutoRefresh,
+		keys.Help,
+		keys.Quit,
+	)
 }
 
 // UpdateKeybindings updates the footer text with custom key bindings

--- a/internal/ui/components/help_modal.go
+++ b/internal/ui/components/help_modal.go
@@ -1,9 +1,12 @@
 package components
 
 import (
+	"fmt"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"strings"
 
+	"github.com/devnullvoid/proxmox-tui/internal/config"
 	"github.com/devnullvoid/proxmox-tui/pkg/api"
 )
 
@@ -15,7 +18,7 @@ type HelpModal struct {
 }
 
 // NewHelpModal creates a new help modal
-func NewHelpModal() *HelpModal {
+func NewHelpModal(keys config.KeyBindings) *HelpModal {
 	// Create a scrollable text view for the help content
 	textView := tview.NewTextView()
 	textView.SetDynamicColors(true)
@@ -26,22 +29,22 @@ func NewHelpModal() *HelpModal {
 	textView.SetTitleColor(tcell.ColorYellow)
 	textView.SetBorderColor(tcell.ColorYellow)
 
-	helpText := `[yellow]Navigation:[-]
+	helpText := fmt.Sprintf(`[yellow]Navigation:[-]
   [white]Arrow Keys / hjkl[-]         Navigate lists and panels
-  [white]Tab[-]                       Switch between Nodes and Guests
-  [white]F1[-]                        Switch to Nodes tab
-  [white]F2[-]                        Switch to Guests tab
-  [white]F3[-]                        Switch to Tasks tab
+  [white]%s[-]                       Switch between Nodes and Guests
+  [white]%s[-]                        Switch to Nodes tab
+  [white]%s[-]                        Switch to Guests tab
+  [white]%s[-]                        Switch to Tasks tab
 
 [yellow]Actions:[-]
-  [white]/[-]                         Search/Filter current list
-  [white]S[-]                         Open SSH shell (node/guest)
-  [white]V[-]                         Open VNC console (node/guest)
-  [white]M[-]                         Open context menu
-  [white]C[-]                         Install community scripts (nodes)
-  [white]R[-]                         Manual refresh
-  [white]A[-]                         Toggle auto-refresh (10s interval)
-  [white]Q[-]                         Quit application (confirms if VNC sessions active)
+  [white]%s[-]                         Search/Filter current list
+  [white]%s[-]                         Open SSH shell (node/guest)
+  [white]%s[-]                         Open VNC console (node/guest)
+  [white]%s[-]                         Open context menu
+  [white]%s[-]                         Install community scripts (nodes)
+  [white]%s[-]                         Manual refresh
+  [white]%s[-]                         Toggle auto-refresh (10s interval)
+  [white]%s[-]                         Quit application (confirms if VNC sessions active)
 
 [yellow]VI-like Navigation:[-]
   [white]h[-]                         Move left / Go back
@@ -68,8 +71,8 @@ func NewHelpModal() *HelpModal {
   [white]Guests:[-]                   Shell, VNC, Start/Stop/Restart/Migrate
 
 [yellow]Tips & Usage:[-]
-  • Use search ([white]/[-]) to quickly find nodes or guests
-  • Context menu ([white]M[-]) provides quick access to actions
+  • Use search ([white]%s[-]) to quickly find nodes or guests
+  • Context menu ([white]%s[-]) provides quick access to actions
   • VNC opens in your browser using embedded noVNC client
   • SSH sessions open in new terminal windows
   • Community scripts are installed interactively via SSH
@@ -82,14 +85,17 @@ func NewHelpModal() *HelpModal {
   • If VNC doesn't open, check your default browser settings
   • SSH requires proper key-based authentication or password
   • Community scripts require internet access on the target node
-  • Use [white]R[-] to manually refresh if data seems stale
+  • Use [white]%s[-] to manually refresh if data seems stale
 
 [yellow]Scrolling in Help:[-]
   [white]Arrow Keys / jk[-]           Scroll up/down through help content
   [white]Page Up/Down[-]              Scroll by page
   [white]Home/End[-]                  Go to top/bottom
 
-[gray]Press [white]?[-][gray] again, [white]Escape[-][gray], or [white]q[-][gray] to exit this help[-]`
+[gray]Press [white]%s[-][gray] again, [white]Escape[-][gray], or [white]%s[-][gray] to exit this help[-]`,
+		keys.SwitchView, keys.NodesPage, keys.GuestsPage, keys.TasksPage,
+		keys.Search, keys.Shell, keys.VNC, keys.Menu, keys.Scripts, keys.Refresh, keys.AutoRefresh, keys.Quit,
+		keys.Search, keys.Menu, keys.Refresh, keys.Help, strings.ToLower(keys.Quit))
 
 	textView.SetText(helpText)
 


### PR DESCRIPTION
## Summary
- reject reserved and duplicate key bindings during validation
- document reserved keys in README and sample config
- add tests for key binding validation
- block system combinations like Ctrl+C

## Testing
- `git submodule update --init --recursive`
- `make build`
- `make lint`
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6866306ff54c8328b999a035f40c8ac3