### PR TITLE
Refresh VNC session activity during proxying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for SOPS/age encrypted configuration files with automatic key lookup
 - `.sops.yaml` for convenient encryption of config files with SOPS
 - Log message when encrypted config is decrypted
+### Fixed
+- Refresh VNC session `LastUsed` timestamp on all WebSocket proxy traffic to prevent unexpected timeouts
 
 ## [0.8.0-rc1] - 2025-07-04
 

--- a/internal/vnc/proxy.go
+++ b/internal/vnc/proxy.go
@@ -52,6 +52,7 @@ type WebSocketProxy struct {
 type SessionNotifier interface {
 	OnClientConnected()
 	OnClientDisconnected()
+	UpdateLastUsed()
 }
 
 // NewWebSocketProxy creates a new WebSocket proxy with the given configuration
@@ -200,6 +201,9 @@ func (p *WebSocketProxy) HandleWebSocketProxy(w http.ResponseWriter, r *http.Req
 					return
 				}
 				p.logger.Debug("Sent keepalive pings for %s", targetName)
+				if p.session != nil {
+					p.session.UpdateLastUsed()
+				}
 			case <-ctx.Done():
 				return
 			}
@@ -354,6 +358,9 @@ func (p *WebSocketProxy) proxyMessages(src, dst *websocket.Conn, direction, targ
 			p.logger.Error("Write error (%s) for %s after %d messages: %v",
 				direction, targetName, messageCount, err)
 			return fmt.Errorf("write error (%s): %w", direction, err)
+		}
+		if p.session != nil {
+			p.session.UpdateLastUsed()
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- refresh LastUsed timestamp whenever the WebSocket proxy forwards traffic
- document the session timeout fix in the changelog

## Testing
- `make build`
- `make lint`
- `go vet ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6869d13e69748328872bafc77680e22a